### PR TITLE
Compatibility with Autofac v6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,23 +6,193 @@
 root = true
 
 [*]
-end_of_line = CRLF
-
-[*.{config,cs,xml}]
 indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+; .NET Code - almost, but not exactly, the same suggestions as corefx
+; https://github.com/dotnet/corefx/blob/master/.editorconfig
+[*.cs]
 indent_size = 4
-trim_trailing_whitespace = true
+charset = utf-8-bom
 
-[*.{proj,props,sln,targets}]
+; New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+; Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+; Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+; Avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+; Types: use keywords instead of BCL types, using var is fine.
+csharp_style_var_when_type_is_apparent = false:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+; Name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+; Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+
+; Static readonly fields should be PascalCase
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
+
+; Internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+; Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:refactoring
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+; Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+; Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:refactoring
+csharp_style_expression_bodied_constructors = true:refactoring
+csharp_style_expression_bodied_operators = true:refactoring
+csharp_style_expression_bodied_properties = true:refactoring
+csharp_style_expression_bodied_indexers = true:refactoring
+csharp_style_expression_bodied_accessors = true:refactoring
+csharp_style_expression_bodied_lambdas = true:refactoring
+csharp_style_expression_bodied_local_functions = true:refactoring
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+; .NET project files and MSBuild - match defaults for VS
+[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
+indent_size = 2
+
+; .NET solution files - match defaults for VS
+[*.sln]
 indent_style = tab
-trim_trailing_whitespace = true
 
-[*.{kproj,csproj,json,ps1,psd1,psm1,resx,rst}]
-indent_style = space
+; Config - match XML and default nuget.config template
+[*.config]
 indent_size = 2
-trim_trailing_whitespace = true
 
-[NuGet.Config]
-indent_style = space
+; Resources - match defaults for VS
+[*.resx]
 indent_size = 2
-trim_trailing_whitespace = true
+
+; Static analysis rulesets - match defaults for VS
+[*.ruleset]
+indent_size = 2
+
+; HTML, XML - match defaults for VS
+[*.{cshtml,html,xml}]
+indent_size = 4
+
+; JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
+[*.{js,json,ts,vue}]
+indent_size = 2
+
+; Markdown - match markdownlint settings
+[*.{md,markdown}]
+indent_size = 2
+
+; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+charset = utf-8-bom
+
+; ReStructuredText - standard indentation format from examples
+[*.rst]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Project specific files
 artifacts/
+BenchmarkDotNet.Artifacts/
 
 # User-specific files
 *.suo
@@ -82,6 +83,11 @@ _TeamCity*
 
 # DotCover is a Code Coverage Tool
 *.dotCover
+
+# Coverage
+coverage.*
+codecov.sh
+coverage/
 
 # NCrunch
 *.ncrunch*
@@ -164,3 +170,6 @@ $RECYCLE.BIN/
 
 # Mac crap
 .DS_Store
+
+# JetBrains Rider
+.idea

--- a/Autofac.Extras.AttributeMetadata.sln
+++ b/Autofac.Extras.AttributeMetadata.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
 		global.json = global.json
+		NuGet.Config = NuGet.Config
 	EndProjectSection
 EndProject
 Global

--- a/Autofac.Extras.AttributeMetadata.sln
+++ b/Autofac.Extras.AttributeMetadata.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E8DAFEB3-0CA6-40AA-ACC6-BA5B77C36BB3}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
+		build.ps1 = build.ps1
 		global.json = global.json
 		NuGet.Config = NuGet.Config
 	EndProjectSection

--- a/Autofac.Extras.AttributeMetadata.sln
+++ b/Autofac.Extras.AttributeMetadata.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
 		build.ps1 = build.ps1
+		codecov.yml = codecov.yml
 		global.json = global.json
 		NuGet.Config = NuGet.Config
 	EndProjectSection

--- a/Autofac.Extras.AttributeMetadata.sln
+++ b/Autofac.Extras.AttributeMetadata.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		codecov.yml = codecov.yml
 		global.json = global.json
 		NuGet.Config = NuGet.Config
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,7 @@
     <clear/>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Xunit MyGet" value="https://myget.org/F/xunit/api/v3/index.json" protocolVersion="3" />
+    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v3/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>
     <add key="Microsoft and .NET" value="true" />

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Attribute metadata support for Autofac IoC
 
-[![Build status](https://ci.appveyor.com/api/projects/status/1jq4bf5hp4gpx0u1?svg=true)](https://ci.appveyor.com/project/Autofac/autofac-extras-attributemetadata)
+[![Build status](https://ci.appveyor.com/api/projects/status/1jq4bf5hp4gpx0u1?svg=true)](https://ci.appveyor.com/project/Autofac/autofac-extras-attributemetadata) [![codecov](https://codecov.io/gh/Autofac/Autofac.Extras.AttributeMetadata/branch/develop/graph/badge.svg)](https://codecov.io/gh/Autofac/Autofac.Extras.AttributeMetadata)
 
 Please file issues and pull requests for this package in this repository rather than in the Autofac core repo.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,13 @@
-version: 5.0.0.{build}
+image: Ubuntu
+
+version: 6.0.0.{build}
+
+dotnet_csproj:
+  version_prefix: '6.0.0'
+  patch: true
+  file: 'src\**\*.csproj'
 
 configuration: Release
-
-image: Visual Studio 2019
 
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -18,7 +23,7 @@ clone_depth: 1
 test: off
 
 build_script:
-- ps: .\build.ps1
+  - pwsh: .\build.ps1
 
 artifacts:
 - path: artifacts\packages\**\*.nupkg

--- a/build.ps1
+++ b/build.ps1
@@ -2,45 +2,66 @@
 # THE BUILD!
 ########################
 
+param (
+    [switch]$Bench = $false
+)
+
 Push-Location $PSScriptRoot
-Import-Module $PSScriptRoot\Build\Autofac.Build.psd1 -Force
+try {
+    Import-Module $PSScriptRoot/build/Autofac.Build.psd1 -Force
 
-$artifactsPath = "$PSScriptRoot\artifacts"
-$packagesPath = "$artifactsPath\packages"
-$sdkVersion = (Get-Content "$PSScriptRoot\global.json" | ConvertFrom-Json).sdk.version
+    $artifactsPath = "$PSScriptRoot/artifacts"
+    $packagesPath = "$artifactsPath/packages"
+    $sdkVersion = (Get-Content "$PSScriptRoot/global.json" | ConvertFrom-Json).sdk.version
 
-# Clean up artifacts folder
-if (Test-Path $artifactsPath) {
-    Write-Message "Cleaning $artifactsPath folder"
-    Remove-Item $artifactsPath -Force -Recurse
+    # Clean up artifacts folder
+    if (Test-Path $artifactsPath) {
+        Write-Message "Cleaning $artifactsPath folder"
+        Remove-Item $artifactsPath -Force -Recurse
+    }
+
+    # Install dotnet CLI
+    Write-Message "Installing .NET Core SDK version $sdkVersion"
+    Install-DotNetCli -Version $sdkVersion
+
+    # Write out dotnet information
+    & dotnet --info
+
+    # Set version suffix
+    $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$NULL -ne $env:APPVEYOR_REPO_BRANCH];
+    $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$NULL -ne $env:APPVEYOR_BUILD_NUMBER];
+    $versionSuffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)).Replace('/', '-'))-$revision" }[$branch -eq "master" -and $revision -ne "local"]
+
+    Write-Message "Package version suffix is '$versionSuffix'"
+
+    # Package restore
+    Write-Message "Restoring packages"
+    Get-DotNetProjectDirectory -RootPath $PSScriptRoot | Restore-DependencyPackages
+
+    # Build/package
+    Write-Message "Building projects and packages"
+    Get-DotNetProjectDirectory -RootPath $PSScriptRoot\src | Invoke-DotNetPack -PackagesPath $packagesPath -VersionSuffix $versionSuffix
+
+    # Test
+    Write-Message "Executing unit tests"
+    Get-DotNetProjectDirectory -RootPath $PSScriptRoot\test | Invoke-Test
+
+    # Benchmark
+    if ($Bench) {
+        Get-DotNetProjectDirectory -RootPath $PSScriptRoot\bench | Invoke-Test
+        Get-ChildItem -Path $PSScriptRoot\bench -Filter "BenchmarkDotNet.Artifacts" -Directory -Recurse | Move-Item -Destination "$PSScriptRoot\artifacts\benchmarks"
+    }
+
+    if ($env:CI -eq "true") {
+        # Generate Coverage Report
+        Write-Message "Generating Codecov Report"
+        Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+        & bash codecov.sh -f "coverage.info"
+    }
+
+    # Finished
+    Write-Message "Build finished"
 }
-
-# Install dotnet CLI
-Write-Message "Installing .NET Core SDK version $sdkVersion"
-Install-DotNetCli -Version $sdkVersion
-
-# Write out dotnet information
-& dotnet --info
-
-# Set version suffix
-$branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
-$revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
-$versionSuffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
-
-Write-Message "Package version suffix is '$versionSuffix'"
-
-# Package restore
-Write-Message "Restoring packages"
-Get-DotNetProjectDirectory -RootPath $PSScriptRoot | Restore-DependencyPackages
-
-# Build/package
-Write-Message "Building projects and packages"
-Get-DotNetProjectDirectory -RootPath $PSScriptRoot\src | Invoke-DotNetPack -PackagesPath $packagesPath -VersionSuffix $versionSuffix
-
-# Test
-Write-Message "Executing unit tests"
-Get-DotNetProjectDirectory -RootPath $PSScriptRoot\test | Invoke-Test
-
-# Finished
-Write-Message "Build finished"
-Pop-Location
+finally {
+    Pop-Location
+}

--- a/build/Analyzers.ruleset
+++ b/build/Analyzers.ruleset
@@ -1,7 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="14.0">
-  <!-- https://github.com/dotnet/roslyn/blob/master/docs/compilers/Rule%20Set%20Format.md -->
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+    <Rule Id="CA1032" Action="None" />
+    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <Rule Id="CA1716" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <Rule Id="CA2229" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <Rule Id="CA2237" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this -->
     <Rule Id="SA1101" Action="None" />
@@ -25,12 +34,8 @@
     <Rule Id="SA1309" Action="None" />
     <!-- Suppressions must have a justification -->
     <Rule Id="SA1404" Action="None" />
-    <!-- No single-line statements involving braces -->
-    <Rule Id="SA1501" Action="None" />
-    <!-- Braces must not be omitted -->
-    <Rule Id="SA1503" Action="None" />
-    <!-- Element must be documented -->
-    <Rule Id="SA1600" Action="None" />
+    <!-- Use trailing comma in initializers - lots of false positives for enums in StyleCop 1.1.0-beta004 -->
+    <Rule Id="SA1413" Action="None" />
     <!-- Parameter documentation mus be in the right order -->
     <Rule Id="SA1612" Action="None" />
     <!-- Return value must be documented -->

--- a/build/Autofac.Build.psd1
+++ b/build/Autofac.Build.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = '.\Autofac.Build.psm1'
-    ModuleVersion = '0.2.0'
+    ModuleVersion = '0.3.0'
     GUID = '55d3f738-f48f-4497-9b2c-ecd90ec1f978'
     Author = 'Autofac Contributors'
     CompanyName = 'Autofac'

--- a/build/Autofac.Build.psm1
+++ b/build/Autofac.Build.psm1
@@ -5,86 +5,66 @@
 # 4: dotnet / NuGet package restore failure
 
 <#
- .SYNOPSIS
-  Writes a build progress message to the host.
+.SYNOPSIS
+    Gets the set of directories in which projects are available for compile/processing.
 
- .PARAMETER Message
-  The message to write.
+.PARAMETER RootPath
+    Path where searching for project directories should begin.
 #>
-function Write-Message
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False, ValueFromPipelineByPropertyName=$False)]
-    [ValidateNotNullOrEmpty()]
-    [string]
-    $Message
-  )
+function Get-DotNetProjectDirectory {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False, ValueFromPipelineByPropertyName = $False)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $RootPath
+    )
 
-  Write-Host "[BUILD] $Message" -ForegroundColor Cyan
+    Get-ChildItem -Path $RootPath -Recurse -Include "*.csproj" | Select-Object @{ Name = "ParentFolder"; Expression = { $_.Directory.FullName.TrimEnd("\") } } | Select-Object -ExpandProperty ParentFolder
 }
 
 <#
- .SYNOPSIS
-  Gets the set of directories in which projects are available for compile/processing.
-
- .PARAMETER RootPath
-  Path where searching for project directories should begin.
+.SYNOPSIS
+    Runs the dotnet CLI install script from GitHub to install a project-local
+    copy of the CLI.
 #>
-function Get-DotNetProjectDirectory
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False, ValueFromPipelineByPropertyName=$False)]
-    [ValidateNotNullOrEmpty()]
-    [string]
-    $RootPath
-  )
+function Install-DotNetCli {
+    [CmdletBinding()]
+    Param(
+        [string]
+        $Version = "Latest"
+    )
 
-  Get-ChildItem -Path $RootPath -Recurse -Include "*.csproj" | Select-Object @{ Name="ParentFolder"; Expression={ $_.Directory.FullName.TrimEnd("\") } } | Select-Object -ExpandProperty ParentFolder
-}
-
-<#
- .SYNOPSIS
-  Runs the dotnet CLI install script from GitHub to install a project-local
-  copy of the CLI.
-#>
-function Install-DotNetCli
-{
-  [CmdletBinding()]
-  Param(
-    [string]
-    $Version = "Latest"
-  )
-
-  if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue))
-  {
-    $installedVersion = dotnet --version
-    if ($installedVersion -eq $Version)
-    {
-      Write-Message ".NET Core SDK version $Version is already installed"
-      return;
+    if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue)) {
+        $installedVersion = dotnet --version
+        if ($installedVersion -eq $Version) {
+            Write-Message ".NET Core SDK version $Version is already installed"
+            return;
+        }
     }
-  }
 
-  $callerPath = Split-Path $MyInvocation.PSCommandPath
-  $installDir = Join-Path -Path $callerPath -ChildPath ".dotnet\cli"
-  if (!(Test-Path $installDir))
-  {
-    New-Item -ItemType Directory -Path "$installDir" | Out-Null
-  }
+    $callerPath = Split-Path $MyInvocation.PSCommandPath
+    $installDir = Join-Path -Path $callerPath -ChildPath ".dotnet/cli"
+    if (!(Test-Path $installDir)) {
+        New-Item -ItemType Directory -Path "$installDir" | Out-Null
+    }
 
-  # Download the dotnet CLI install script
-  if (!(Test-Path .\dotnet\install.ps1))
-  {
-    Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile ".\.dotnet\dotnet-install.ps1"
-  }
+    # Download the dotnet CLI install script
+    if ($IsWindows) {
+        if (!(Test-Path ./.dotnet/dotnet-install.ps1)) {
+            Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "./.dotnet/dotnet-install.ps1"
+        }
 
-  # Run the dotnet CLI install
-  & .\.dotnet\dotnet-install.ps1 -InstallDir "$installDir" -Version $Version
+        & ./.dotnet/dotnet-install.ps1 -InstallDir "$installDir" -Version $Version
+        $env:PATH = "$installDir;$env:PATH"
+    } else {
+        if (!(Test-Path ./.dotnet/dotnet-install.sh)) {
+            Invoke-WebRequest "https://dot.net/v1/dotnet-install.sh" -OutFile "./.dotnet/dotnet-install.sh"
+        }
 
-  # Add the dotnet folder path to the process.
-  $env:PATH = "$installDir;$env:PATH"
+        & bash ./.dotnet/dotnet-install.sh --install-dir "$installDir" --version $Version
+        $env:PATH = "$installDir`:$env:PATH"
+    }
 }
 
 <#
@@ -95,156 +75,162 @@ function Install-DotNetCli
 .PARAMETER DirectoryName
     The path to the directory containing the project to build.
 #>
-function Invoke-DotNetBuild
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory
-  )
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      & dotnet build ("""" + $Project.FullName + """") --configuration Release
-      if ($LASTEXITCODE -ne 0)
-      {
-        exit 1
-      }
+function Invoke-DotNetBuild {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory
+    )
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            & dotnet build ("""" + $Project.FullName + """") --configuration Release
+            if ($LASTEXITCODE -ne 0) {
+                exit 1
+            }
+        }
     }
-  }
 }
 
 <#
- .SYNOPSIS
-  Invokes the dotnet utility to package a project.
+.SYNOPSIS
+    Invokes the dotnet utility to package a project.
 
- .PARAMETER ProjectDirectory
-  Path to the directory containing the project to package.
+.PARAMETER ProjectDirectory
+    Path to the directory containing the project to package.
 
- .PARAMETER PackagesPath
-  Path to the "artifacts\packages" folder where packages should go.
+.PARAMETER PackagesPath
+    Path to the "artifacts/packages" folder where packages should go.
 
- .PARAMETER VersionSuffix
-  The version suffix to use for the NuGet package version.
+.PARAMETER VersionSuffix
+    The version suffix to use for the NuGet package version.
 #>
-function Invoke-DotNetPack
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory,
+function Invoke-DotNetPack {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory,
 
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo]
-    $PackagesPath,
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo]
+        $PackagesPath,
 
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False)]
-    [AllowEmptyString()]
-    [string]
-    $VersionSuffix
-  )
-  Begin
-  {
-    New-Item -Path $PackagesPath -ItemType Directory -Force | Out-Null
-  }
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      if ($VersionSuffix -eq "")
-      {
-        & dotnet build ("""" + $Project.FullName + """") --configuration Release
-      }
-      else
-      {
-        & dotnet build ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix
-      }
-      if ($LASTEXITCODE -ne 0)
-      {
-        exit 1
-      }
-
-      if ($VersionSuffix -eq "")
-      {
-        & dotnet pack ("""" + $Project.FullName + """") --configuration Release --output $PackagesPath
-      }
-      else
-      {
-        & dotnet pack ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix --output $PackagesPath
-      }
-      if ($LASTEXITCODE -ne 0)
-      {
-        exit 1
-      }
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False)]
+        [AllowEmptyString()]
+        [string]
+        $VersionSuffix
+    )
+    Begin {
+        New-Item -Path $PackagesPath -ItemType Directory -Force | Out-Null
     }
-  }
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            if ($VersionSuffix -eq "") {
+                & dotnet build ("""" + $Project.FullName + """") --configuration Release
+            }
+            else {
+                & dotnet build ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix
+            }
+            if ($LASTEXITCODE -ne 0) {
+                exit 1
+            }
+
+            if ($VersionSuffix -eq "") {
+                & dotnet pack ("""" + $Project.FullName + """") --configuration Release --output $PackagesPath
+            }
+            else {
+                & dotnet pack ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix --output $PackagesPath
+            }
+            if ($LASTEXITCODE -ne 0) {
+                exit 1
+            }
+        }
+    }
 }
 
 <#
- .Synopsis
-  Invokes dotnet test command.
+.SYNOPSIS
+    Invokes dotnet test command.
 
- .Parameter ProjectDirectory
-  Path to the directory containing the project to package.
+.PARAMETER ProjectDirectory
+    Path to the directory containing the project to package.
 #>
-function Invoke-Test
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory
-  )
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      Push-Location $Project
+function Invoke-Test {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory
+    )
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            Push-Location $Project
 
-      & dotnet test --configuration Release --logger:trx
-      if ($LASTEXITCODE -ne 0)
-      {
-        Pop-Location
-        exit 3
-      }
+            & dotnet test `
+                --configuration Release `
+                --logger:trx `
+                /p:CollectCoverage=true `
+                /p:CoverletOutput="..\..\" `
+                /p:MergeWith="..\..\coverage.json" `
+                /p:CoverletOutputFormat="json%2clcov" `
+                /p:ExcludeByAttribute=CompilerGeneratedAttribute `
+                /p:ExcludeByAttribute=GeneratedCodeAttribute
 
-      Pop-Location
+            if ($LASTEXITCODE -ne 0) {
+                Pop-Location
+                exit 3
+            }
+
+            Pop-Location
+        }
     }
-  }
 }
 
 <#
- .SYNOPSIS
-  Restores dependencies using the dotnet utility.
+.SYNOPSIS
+    Restores dependencies using the dotnet utility.
 
- .PARAMETER ProjectDirectory
-  Path to the directory containing the project with dependencies to restore.
+.PARAMETER ProjectDirectory
+    Path to the directory containing the project with dependencies to restore.
 #>
-function Restore-DependencyPackages
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory
-  )
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      & dotnet restore ("""" + $Project.FullName + """") --no-cache
-      if($LASTEXITCODE -ne 0)
-      {
-        exit 4
-      }
+function Restore-DependencyPackages {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory
+    )
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            & dotnet restore ("""" + $Project.FullName + """") --no-cache
+            if ($LASTEXITCODE -ne 0) {
+                exit 4
+            }
+        }
     }
-  }
+}
+
+<#
+.SYNOPSIS
+    Writes a build progress message to the host.
+
+.PARAMETER Message
+    The message to write.
+#>
+function Write-Message {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False, ValueFromPipelineByPropertyName = $False)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Message
+    )
+
+    Write-Host "[BUILD] $Message" -ForegroundColor Cyan
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  branch: develop
+  require_ci_to_pass: yes
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100"
+    "version": "3.1.302",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Autofac.Extras.AttributeMetadata/AttributedMetadataModule.cs
+++ b/src/Autofac.Extras.AttributeMetadata/AttributedMetadataModule.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright (c) 2007 - 2013 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using Autofac.Core;
@@ -44,7 +22,10 @@ namespace Autofac.Extras.AttributeMetadata
         /// <param name="registration">The registration to attach functionality to.</param>
         protected override void AttachToComponentRegistration(IComponentRegistryBuilder componentRegistry, IComponentRegistration registration)
         {
-            if (registration == null) throw new ArgumentNullException(nameof(registration));
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
 
             foreach (var property in MetadataHelper.GetMetadata(registration.Activator.LimitType))
             {

--- a/src/Autofac.Extras.AttributeMetadata/Autofac.Extras.AttributeMetadata.csproj
+++ b/src/Autofac.Extras.AttributeMetadata/Autofac.Extras.AttributeMetadata.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <Description>Autofac allows you to register metadata along with dependencies for additional resolution flexibility. This extension enables that metadata to be registered through attributes.</Description>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <!-- VersionPrefix patched by AppVeyor -->
+    <VersionPrefix>0.0.1</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);IDE0008</NoWarn>
@@ -10,7 +11,6 @@
     <AssemblyName>Autofac.Extras.AttributeMetadata</AssemblyName>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Autofac.Extras.AttributeMetadata</PackageId>
     <PackageTags>autofac;di;ioc;dependencyinjection;aspnet;aspnetcore</PackageTags>
     <PackageReleaseNotes>Release notes are at https://github.com/autofac/Autofac.Extras.AttributeMetadata/releases</PackageReleaseNotes>
@@ -28,6 +28,7 @@
     <EmbedAllSources>true</EmbedAllSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Features>$(Features);IOperation</Features>
+    <Copyright>Copyright © 2013 Autofac Contributors</Copyright>
     <Authors>Autofac Contributors</Authors>
     <Company>Autofac</Company>
     <Product>Autofac</Product>
@@ -39,12 +40,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="5.0.0" />
-    <PackageReference Include="Autofac.Mef" Version="5.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
+    <PackageReference Include="Autofac" Version="6.0.0-feature-he-01138" />
+    <PackageReference Include="Autofac.Mef" Version="6.0.0-develop-00247" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">

--- a/src/Autofac.Extras.AttributeMetadata/AutofacAttributeExtensions.cs
+++ b/src/Autofac.Extras.AttributeMetadata/AutofacAttributeExtensions.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright © 2013 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Linq;
@@ -52,7 +30,10 @@ namespace Autofac.Extras.AttributeMetadata
             WithAttributedMetadata<TLimit, TScanningActivatorData, TRegistrationStyle>(this IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle> builder)
                 where TScanningActivatorData : ScanningActivatorData
         {
-            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
 
             builder.ActivatorData.ConfigurationActions.Add(
                 (t, rb) => rb.WithMetadata(MetadataHelper.GetMetadata(t)));
@@ -74,7 +55,10 @@ namespace Autofac.Extras.AttributeMetadata
         public static IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
             WithAttributedMetadata<TMetadata>(this IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> builder)
         {
-            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
 
             builder.ActivatorData.ConfigurationActions.Add(
                 (t, rb) => rb.WithMetadata(MetadataHelper.GetMetadata<TMetadata>(t)));
@@ -111,7 +95,10 @@ namespace Autofac.Extras.AttributeMetadata
                 this IRegistrationBuilder<TLimit, TReflectionActivatorData, TRegistrationStyle> builder)
             where TReflectionActivatorData : ReflectionActivatorData
         {
-            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
 
 #pragma warning disable CS0618
             return builder.WithParameter(

--- a/src/Autofac.Extras.AttributeMetadata/IMetadataProvider.cs
+++ b/src/Autofac.Extras.AttributeMetadata/IMetadataProvider.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright (c) 2007 - 2013 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Autofac.Extras.AttributeMetadata/IMetadataRegistrar{TInterface,TMetadata}.cs
+++ b/src/Autofac.Extras.AttributeMetadata/IMetadataRegistrar{TInterface,TMetadata}.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright © 2013 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using Autofac.Builder;

--- a/src/Autofac.Extras.AttributeMetadata/MetadataHelper.cs
+++ b/src/Autofac.Extras.AttributeMetadata/MetadataHelper.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright (c) 2007 - 2013 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -45,13 +23,20 @@ namespace Autofac.Extras.AttributeMetadata
         /// <see cref="IMetadataProvider"/>.
         /// </param>
         /// <returns>Enumerable set of property names and associated values.</returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// Thrown if <paramref name="target" /> or <paramref name="instanceType"/> is <see langword="null" />.
         /// </exception>
         public static IEnumerable<KeyValuePair<string, object>> GetProperties(object target, Type instanceType)
         {
-            if (target == null) throw new ArgumentNullException(nameof(target));
-            if (instanceType == null) throw new ArgumentNullException(nameof(instanceType));
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            if (instanceType == null)
+            {
+                throw new ArgumentNullException(nameof(instanceType));
+            }
 
             if (target is IMetadataProvider asProvider)
             {
@@ -73,12 +58,15 @@ namespace Autofac.Extras.AttributeMetadata
         /// </summary>
         /// <param name="targetType">Type to interrogate for metadata attributes.</param>
         /// <returns>Enumerable set of property names and associated values found.</returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// Thrown if <paramref name="targetType" /> is <see langword="null" />.
         /// </exception>
         public static IEnumerable<KeyValuePair<string, object>> GetMetadata(Type targetType)
         {
-            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            if (targetType == null)
+            {
+                throw new ArgumentNullException(nameof(targetType));
+            }
 
             var propertyList = new List<KeyValuePair<string, object>>();
 
@@ -104,7 +92,10 @@ namespace Autofac.Extras.AttributeMetadata
         /// </exception>
         public static IEnumerable<KeyValuePair<string, object>> GetMetadata<TMetadataType>(Type targetType)
         {
-            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            if (targetType == null)
+            {
+                throw new ArgumentNullException(nameof(targetType));
+            }
 
             var attribute = (from p in targetType.GetCustomAttributes(typeof(TMetadataType), true) select p).FirstOrDefault();
 

--- a/src/Autofac.Extras.AttributeMetadata/MetadataModule{TInterface,TMetadata}.cs
+++ b/src/Autofac.Extras.AttributeMetadata/MetadataModule{TInterface,TMetadata}.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright © 2013 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using Autofac.Builder;

--- a/src/Autofac.Extras.AttributeMetadata/ParameterFilterAttribute.cs
+++ b/src/Autofac.Extras.AttributeMetadata/ParameterFilterAttribute.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright (c) 2007 - 2013 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Reflection;

--- a/src/Autofac.Extras.AttributeMetadata/WithKeyAttribute.cs
+++ b/src/Autofac.Extras.AttributeMetadata/WithKeyAttribute.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright © 2013 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -127,13 +105,20 @@ namespace Autofac.Extras.AttributeMetadata
         /// <returns>
         /// The instance of the object that should be used for the parameter value.
         /// </returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// Thrown if <paramref name="parameter" /> or <paramref name="context" /> is <see langword="null" />.
         /// </exception>
         public override object ResolveParameter(ParameterInfo parameter, IComponentContext context)
         {
-            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
-            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
             context.TryResolveKeyed(Key, parameter.ParameterType, out var value);
             return value;

--- a/src/Autofac.Extras.AttributeMetadata/WithMetadataAttribute.cs
+++ b/src/Autofac.Extras.AttributeMetadata/WithMetadataAttribute.cs
@@ -1,27 +1,5 @@
-﻿// This software is part of the Autofac IoC container
-// Copyright © 2013 Autofac Contributors
-// https://autofac.org
-//
-// Permission is hereby granted, free of charge, to any person
-// obtaining a copy of this software and associated documentation
-// files (the "Software"), to deal in the Software without
-// restriction, including without limitation the rights to use,
-// copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following
-// conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-// OTHER DEALINGS IN THE SOFTWARE.
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -166,8 +144,15 @@ namespace Autofac.Extras.AttributeMetadata
         /// </exception>
         public override object ResolveParameter(ParameterInfo parameter, IComponentContext context)
         {
-            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
-            if (context == null) throw new ArgumentNullException(nameof(context));
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
             // GetElementType currently is the effective equivalent of "Determine if the type
             // is in IEnumerable and if it is, get the type being enumerated." This doesn't support

--- a/test/Autofac.Extras.AttributeMetadata.Test/Autofac.Extras.AttributeMetadata.Test.csproj
+++ b/test/Autofac.Extras.AttributeMetadata.Test/Autofac.Extras.AttributeMetadata.Test.csproj
@@ -27,6 +27,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Autofac.Extras.AttributeMetadata.Test/Autofac.Extras.AttributeMetadata.Test.csproj
+++ b/test/Autofac.Extras.AttributeMetadata.Test/Autofac.Extras.AttributeMetadata.Test.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NoWarn>$(NoWarn);CS1591;SA1600</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac.Extras.AttributeMetadata.Test</AssemblyName>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -19,14 +18,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Upgrade to v6 packages for `Autofac` and `Autofac.Mef`
- Bump version to `6.0.0`
- Update build assets and build script
- Change build image Ubuntu
- Add coverlet packages
- Switch to short copyright headers
- Fix code style issues
- Remove unnecessary `System.Reflection.Emit` packages from test project