### PR TITLE
Remove obsolete AppVeyor VersionPrefix from csproj

### DIFF
--- a/src/Autofac.Extras.AttributeMetadata/Autofac.Extras.AttributeMetadata.csproj
+++ b/src/Autofac.Extras.AttributeMetadata/Autofac.Extras.AttributeMetadata.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <Description>Autofac allows you to register metadata along with dependencies for additional resolution flexibility. This extension enables that metadata to be registered through attributes.</Description>
-    <!-- VersionPrefix patched by AppVeyor -->
-    <VersionPrefix>0.0.1</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);IDE0008</NoWarn>


### PR DESCRIPTION
## Summary
- Removes the `<VersionPrefix>` property and associated AppVeyor comment from the source .csproj
- Version is set by `default.proj` via `/p:Version` during GitHub Actions CI, making the csproj entry unnecessary
- Eliminates risk of accidentally building with a dummy `0.0.1` version outside the normal pipeline

## Test plan
- [ ] CI build passes (version still correctly set by default.proj)
- [ ] Verify produced package has correct version suffix based on branch