### PR TITLE
Add SonarAnalyzer.CSharp and tighten Roslyn analyzer rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
+  "cSpell.words": [
+    "autofac"
+  ],
   "omnisharp.enableEditorConfigSupport": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": [
-    "autofac"
+    "autofac",
+    "xunit"
   ],
   "omnisharp.enableEditorConfigSupport": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,6 +3,7 @@
     {
       "args": [
         "build",
+        "Autofac.Extras.AttributeMetadata.sln",
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"
       ],

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -4,6 +4,8 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
     <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
     <!-- Avoid excessive complexity (must be explicitly enabled). -->
@@ -44,6 +46,8 @@
     <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
     <Rule Id="S3267" Action="None" />
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - Autofac uses non-standard dispose patterns for container lifecycle. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <Rule Id="S6418" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -32,6 +32,8 @@
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <!-- "Sonar Way" rules to match SonarQube scans. -->
     <Rule Id="S107" Action="Warning" />
+    <!-- Do not use obsolete members - Autofac maintains deprecated APIs for backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1192" Action="Warning" />
     <Rule Id="S1313" Action="Warning" />
     <Rule Id="S2259" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac source assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -12,22 +12,40 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <!-- Use ArgumentNullException.ThrowIfNull - not available in netstandard. -->
     <Rule Id="CA1510" Action="None" />
-    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - not available below net8.0. -->
     <Rule Id="CA1512" Action="None" />
-    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ObjectDisposedException.ThrowIf - not available below net8.0. -->
     <Rule Id="CA1513" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <!-- Change names to avoid reserved word overlaps - would break public API. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <!-- Cache a CompositeFormat - not available in netstandard. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
-    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <!-- Prefer generic overloads - conflicts with reflection work in Autofac. -->
     <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- "Sonar Way" rules to match SonarQube scans. -->
+    <Rule Id="S107" Action="Warning" />
+    <Rule Id="S1192" Action="Warning" />
+    <Rule Id="S1313" Action="Warning" />
+    <Rule Id="S2259" Action="Warning" />
+    <Rule Id="S2583" Action="Warning" />
+    <Rule Id="S2589" Action="Warning" />
+    <!-- Verify reflection accessibility bypass - DI containers do extensive reflection by design. -->
+    <Rule Id="S3011" Action="None" />
+    <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
+    <Rule Id="S3267" Action="None" />
+    <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
+    <Rule Id="S6418" Action="Warning" />
+    <Rule Id="S6444" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -55,6 +55,8 @@
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
     <!-- Remove unused private members - reflection tests need non-public members. -->
+    <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -42,6 +42,8 @@
     <Rule Id="CA2234" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Nested types should not be visible - test scenario classes use nested types extensively. -->
+    <Rule Id="CA1034" Action="None" />
     <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
   </Rules>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -23,6 +23,10 @@
     <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
     <!-- Internal class that appears to never be instantiated - false positives from DI. -->
+    <!-- Identifiers should not have incorrect suffix - test classes use Impl, Handler, etc. -->
+    <Rule Id="CA1711" Action="None" />
+    <!-- Property names should not match get methods - aggregate service tests intentionally test both. -->
+    <Rule Id="CA1721" Action="None" />
     <Rule Id="CA1812" Action="None" />
     <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
@@ -55,6 +59,8 @@
     <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
     <Rule Id="S1075" Action="None" />
     <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <!-- Sections of code should not be commented out - test files may retain commented examples. -->
+    <Rule Id="S125" Action="None" />
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -39,6 +39,8 @@
     <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
     <!-- Implement serialization constructors - false positive in .NET Core. -->
+    <!-- Do not raise reserved exception types - tests use generic exceptions for simulation. -->
+    <Rule Id="CA2201" Action="None" />
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -6,6 +6,8 @@
     <Rule Id="CA1031" Action="None" />
     <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
@@ -54,9 +56,9 @@
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
-    <!-- Remove unused private members - reflection tests need non-public members. -->
     <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
     <Rule Id="S1133" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />
@@ -80,6 +82,8 @@
     <Rule Id="S2335" Action="None" />
     <!-- Cognitive complexity (must be explicitly enabled). -->
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - test dispose implementations are intentionally simplified. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,16 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac test assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
-    <Rule Id="CA1005" Action="Warning" />
-    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Don't catch general exceptions - test scenarios sometimes require it. -->
     <Rule Id="CA1031" Action="None" />
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
-    <Rule Id="CA1032" Action="None" />
-    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
-    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
+    <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -20,36 +16,78 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
-    <Rule Id="CA1510" Action="None" />
-    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <!-- Make API types internal - causes problems with tests. -->
     <Rule Id="CA1515" Action="None" />
-    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
-    <Rule Id="CA1716" Action="None" />
-    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <!-- Internal class that appears to never be instantiated - false positives from DI. -->
     <Rule Id="CA1812" Action="None" />
-    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
-    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <!-- Mark members static - test methods may not access member data. -->
     <Rule Id="CA1822" Action="None" />
-    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <!-- Use the LoggerMessage delegates - noise in tests, performance irrelevant. -->
+    <Rule Id="CA1848" Action="None" />
+    <!-- Seal internal types - unimportant in tests. -->
     <Rule Id="CA1852" Action="None" />
-    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <!-- Prefer static readonly fields over constant arrays - happens in test setup. -->
     <Rule Id="CA1861" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <!-- Cache a CompositeFormat - makes tests harder to read. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
+    <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
-    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
+    <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
+    <Rule Id="S1075" Action="None" />
+    <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <Rule Id="S1118" Action="None" />
+    <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
+    <Rule Id="S1215" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
+    <Rule Id="S1144" Action="None" />
+    <!-- Empty method bodies - test stubs often have no-op implementations. -->
+    <Rule Id="S1186" Action="None" />
+    <!-- Remove unused method parameters - reflection tests declare parameters not used in the body. -->
+    <Rule Id="S1172" Action="None" />
+    <!-- Remove empty class - test stubs for DI resolution don't need implementation. -->
+    <Rule Id="S2094" Action="None" />
+    <!-- Make member static - test fixture members may not access instance data. -->
+    <Rule Id="S2325" Action="None" />
+    <!-- Remove unused type parameters - used in reflection testing. -->
+    <Rule Id="S2326" Action="None" />
+    <!-- Write-only properties - reflection tests verify property setter behavior. -->
+    <Rule Id="S2376" Action="None" />
+    <!-- Classes with only private constructors - reflection tests verify inaccessible constructors. -->
+    <Rule Id="S3453" Action="None" />
+    <!-- Remove unassigned auto-property - reflection tests verify non-public property behavior. -->
+    <Rule Id="S3459" Action="None" />
+    <!-- Complete the TODO - acceptable in tests for backlog items. -->
+    <Rule Id="S1135" Action="None" />
+    <!-- Make instance property static - false positives in data/document types. -->
+    <Rule Id="S2335" Action="None" />
+    <!-- Cognitive complexity (must be explicitly enabled). -->
+    <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
+    <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->
+    <Rule Id="S2925" Action="None" />
+    <!-- NSubstitute mock verification is complete without property access. -->
+    <Rule Id="S2970" Action="None" />
+    <!-- Fields only assigned in constructor - needed to prevent optimization in reflection tests. -->
+    <Rule Id="S4487" Action="None" />
+    <!-- Set route attributes at top of controller - false positive. -->
+    <Rule Id="S6934" Action="None" />
+    <!-- Use async dispose - sync dispose tests are intentional. -->
+    <Rule Id="S6966" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->
@@ -58,11 +96,11 @@
     <Rule Id="SA1121" Action="None" />
     <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by member type. -->
     <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by visibility. -->
     <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of static vs. non-static members. -->
     <Rule Id="SA1204" Action="None" />
     <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
@@ -82,6 +120,13 @@
     <Rule Id="SA1618" Action="None" />
     <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="xUnit" RuleNamespace="xUnit">
+    <!-- Use Assert.Single when there's only one collection entry. -->
+    <Rule Id="xUnit2023" Action="Warning" />
+  </Rules>
+  <!-- IDE rules for test assemblies. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
     <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />
     <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->

--- a/src/Autofac.Extras.AttributeMetadata/AttributedMetadataModule.cs
+++ b/src/Autofac.Extras.AttributeMetadata/AttributedMetadataModule.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Autofac.Core;
 using Autofac.Core.Registration;
 

--- a/src/Autofac.Extras.AttributeMetadata/Autofac.Extras.AttributeMetadata.csproj
+++ b/src/Autofac.Extras.AttributeMetadata/Autofac.Extras.AttributeMetadata.csproj
@@ -22,6 +22,7 @@
     <Copyright>Copyright © 2015 Autofac Contributors</Copyright>
     <CodeAnalysisRuleSet>../../build/Source.ruleset</CodeAnalysisRuleSet>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedAllSources>true</EmbedAllSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -46,6 +47,10 @@
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Composition" Version="10.0.8" />
   </ItemGroup>

--- a/src/Autofac.Extras.AttributeMetadata/Autofac.Extras.AttributeMetadata.csproj
+++ b/src/Autofac.Extras.AttributeMetadata/Autofac.Extras.AttributeMetadata.csproj
@@ -30,6 +30,7 @@
     <Authors>Autofac Contributors</Authors>
     <Company>Autofac</Company>
     <Product>Autofac</Product>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Autofac.Extras.AttributeMetadata/AutofacAttributeExtensions.cs
+++ b/src/Autofac.Extras.AttributeMetadata/AutofacAttributeExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Linq;
 using Autofac.Builder;
 using Autofac.Features.Scanning;
 

--- a/src/Autofac.Extras.AttributeMetadata/IMetadataProvider.cs
+++ b/src/Autofac.Extras.AttributeMetadata/IMetadataProvider.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace Autofac.Extras.AttributeMetadata;
 
 /// <summary>

--- a/src/Autofac.Extras.AttributeMetadata/IMetadataRegistrar{TInterface,TMetadata}.cs
+++ b/src/Autofac.Extras.AttributeMetadata/IMetadataRegistrar{TInterface,TMetadata}.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Autofac.Builder;
 
 namespace Autofac.Extras.AttributeMetadata;

--- a/src/Autofac.Extras.AttributeMetadata/MetadataHelper.cs
+++ b/src/Autofac.Extras.AttributeMetadata/MetadataHelper.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 
 namespace Autofac.Extras.AttributeMetadata;
 

--- a/src/Autofac.Extras.AttributeMetadata/MetadataModule{TInterface,TMetadata}.cs
+++ b/src/Autofac.Extras.AttributeMetadata/MetadataModule{TInterface,TMetadata}.cs
@@ -43,19 +43,6 @@ public abstract class MetadataModule<TInterface, TMetadata> : Module, IMetadataR
             MetadataHelper.GetProperties(metadata, typeof(TInstance)));
 
     /// <summary>
-    /// Registers the provided concrete instance and scans it for generic metadata attribute data.
-    /// </summary>
-    /// <typeparam name="TInstance">Concrete instance type.</typeparam>
-    /// <returns>
-    /// The registration for continued configuration.
-    /// </returns>
-    public IRegistrationBuilder<TInstance, ConcreteReflectionActivatorData, SingleRegistrationStyle>
-        RegisterAttributedType<TInstance>()
-        where TInstance : TInterface
-        => ContainerBuilder.RegisterType<TInstance>().As<TInterface>().WithMetadata(
-            MetadataHelper.GetMetadata(typeof(TInstance)));
-
-    /// <summary>
     /// registers provided metadata on the declared type.
     /// </summary>
     /// <param name="instanceType">Type of the instance.</param>
@@ -67,6 +54,19 @@ public abstract class MetadataModule<TInterface, TMetadata> : Module, IMetadataR
         Type instanceType, TMetadata metadata)
         => ContainerBuilder.RegisterType(instanceType).As<TInterface>().WithMetadata(
             MetadataHelper.GetProperties(metadata, instanceType));
+
+    /// <summary>
+    /// Registers the provided concrete instance and scans it for generic metadata attribute data.
+    /// </summary>
+    /// <typeparam name="TInstance">Concrete instance type.</typeparam>
+    /// <returns>
+    /// The registration for continued configuration.
+    /// </returns>
+    public IRegistrationBuilder<TInstance, ConcreteReflectionActivatorData, SingleRegistrationStyle>
+        RegisterAttributedType<TInstance>()
+        where TInstance : TInterface
+        => ContainerBuilder.RegisterType<TInstance>().As<TInterface>().WithMetadata(
+            MetadataHelper.GetMetadata(typeof(TInstance)));
 
     /// <summary>
     /// Registers the provided concrete instance type and scans it for generate metadata data.

--- a/src/Autofac.Extras.AttributeMetadata/MetadataModule{TInterface,TMetadata}.cs
+++ b/src/Autofac.Extras.AttributeMetadata/MetadataModule{TInterface,TMetadata}.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Autofac.Builder;
 using Autofac.Integration.Mef;
 

--- a/src/Autofac.Extras.AttributeMetadata/ParameterFilterAttribute.cs
+++ b/src/Autofac.Extras.AttributeMetadata/ParameterFilterAttribute.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Reflection;
 
 namespace Autofac.Extras.AttributeMetadata;

--- a/src/Autofac.Extras.AttributeMetadata/WithKeyAttribute.cs
+++ b/src/Autofac.Extras.AttributeMetadata/WithKeyAttribute.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Autofac.Extras.AttributeMetadata;
@@ -74,7 +73,7 @@ namespace Autofac.Extras.AttributeMetadata;
 /// var explorer = container.Resolve&lt;SolutionExplorer&gt;();
 /// </code>
 /// </example>
-[SuppressMessage("Microsoft.Design", "CA1018:MarkAttributesWithAttributeUsage", Justification = "Allowing the inherited AttributeUsageAttribute to be used avoids accidental override or conflict at this level.")]
+[AttributeUsage(AttributeTargets.Parameter)]
 [Obsolete("Use the Autofac.Features.AttributeFilters.KeyFilterAttribute from the core Autofac library instead.")]
 public sealed class WithKeyAttribute : ParameterFilterAttribute
 {

--- a/src/Autofac.Extras.AttributeMetadata/WithKeyAttribute.cs
+++ b/src/Autofac.Extras.AttributeMetadata/WithKeyAttribute.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Reflection;
 
 namespace Autofac.Extras.AttributeMetadata;

--- a/src/Autofac.Extras.AttributeMetadata/WithMetadataAttribute.cs
+++ b/src/Autofac.Extras.AttributeMetadata/WithMetadataAttribute.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using Autofac.Features.Metadata;
 

--- a/src/Autofac.Extras.AttributeMetadata/WithMetadataAttribute.cs
+++ b/src/Autofac.Extras.AttributeMetadata/WithMetadataAttribute.cs
@@ -77,7 +77,7 @@ namespace Autofac.Extras.AttributeMetadata;
 /// var explorer = container.Resolve&lt;SolutionExplorer&gt;();
 /// </code>
 /// </example>
-[SuppressMessage("Microsoft.Design", "CA1018:MarkAttributesWithAttributeUsage", Justification = "Allowing the inherited AttributeUsageAttribute to be used avoids accidental override or conflict at this level.")]
+[AttributeUsage(AttributeTargets.Parameter)]
 [Obsolete("Use the Autofac.Features.AttributeFilters.MetadataFilterAttribute from the core Autofac library instead.")]
 public sealed class WithMetadataAttribute : ParameterFilterAttribute
 {

--- a/test/Autofac.Extras.AttributeMetadata.Test/Autofac.Extras.AttributeMetadata.Test.csproj
+++ b/test/Autofac.Extras.AttributeMetadata.Test/Autofac.Extras.AttributeMetadata.Test.csproj
@@ -11,13 +11,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="TestResults\**" />
-    <EmbeddedResource Remove="TestResults\**" />
-    <None Remove="TestResults\**" />
-  </ItemGroup>
 
   <ItemGroup>
     <AdditionalFiles Include="../../build/stylecop.json" Link="stylecop.json" />

--- a/test/Autofac.Extras.AttributeMetadata.Test/Autofac.Extras.AttributeMetadata.Test.csproj
+++ b/test/Autofac.Extras.AttributeMetadata.Test/Autofac.Extras.AttributeMetadata.Test.csproj
@@ -7,6 +7,8 @@
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -29,6 +31,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">

--- a/test/Autofac.Extras.AttributeMetadata.Test/CombinationalWeakTypedAttributeScenarioTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/CombinationalWeakTypedAttributeScenarioTestFixture.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using Autofac;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.CombinationalWeakTypedAttributeScenario;
 using Autofac.Integration.Mef;
 using Xunit;

--- a/test/Autofac.Extras.AttributeMetadata.Test/MetadataHelperTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/MetadataHelperTestFixture.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Linq;
-using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.CombinationalWeakTypedAttributeScenario;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.MetadataModuleScenarioDiscoveryTargets;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.StrongTypedMetadataAttributeScenario;

--- a/test/Autofac.Extras.AttributeMetadata.Test/MetadataHelperTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/MetadataHelperTestFixture.cs
@@ -19,8 +19,8 @@ public class MetadataHelperTestFixture
         var metadata = MetadataHelper.GetMetadata(typeof(CombinationalWeakTypedScenario));
 
         Assert.Equal(2, metadata.Count());
-        Assert.Equal("Hello", metadata.Where(p => p.Key == "Name").FirstOrDefault().Value);
-        Assert.Equal(42, metadata.Where(p => p.Key == "Age").FirstOrDefault().Value);
+        Assert.Equal("Hello", metadata.FirstOrDefault(p => p.Key == "Name").Value);
+        Assert.Equal(42, metadata.FirstOrDefault(p => p.Key == "Age").Value);
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class MetadataHelperTestFixture
         var metadata = MetadataHelper.GetMetadata(typeof(WeakTypedScenario));
 
         Assert.Single(metadata);
-        Assert.Equal("Hello", metadata.Where(p => p.Key == "Name").FirstOrDefault().Value);
+        Assert.Equal("Hello", metadata.FirstOrDefault(p => p.Key == "Name").Value);
     }
 
     [Fact]
@@ -38,8 +38,8 @@ public class MetadataHelperTestFixture
         var metadata = MetadataHelper.GetMetadata<IStrongTypedScenarioMetadata>(typeof(StrongTypedScenario));
 
         Assert.Equal(2, metadata.Count());
-        Assert.Equal("Hello", metadata.Where(p => p.Key == "Name").FirstOrDefault().Value);
-        Assert.Equal(42, metadata.Where(p => p.Key == "Age").FirstOrDefault().Value);
+        Assert.Equal("Hello", metadata.FirstOrDefault(p => p.Key == "Name").Value);
+        Assert.Equal(42, metadata.FirstOrDefault(p => p.Key == "Age").Value);
     }
 
     [Fact]

--- a/test/Autofac.Extras.AttributeMetadata.Test/MetadataHelperTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/MetadataHelperTestFixture.cs
@@ -14,9 +14,9 @@ public class MetadataHelperTestFixture
     [Fact]
     public void Scan_multiple_attributes_into_one_enumerable_set()
     {
-        var metadata = MetadataHelper.GetMetadata(typeof(CombinationalWeakTypedScenario));
+        var metadata = MetadataHelper.GetMetadata(typeof(CombinationalWeakTypedScenario)).ToList();
 
-        Assert.Equal(2, metadata.Count());
+        Assert.Equal(2, metadata.Count);
         Assert.Equal("Hello", metadata.FirstOrDefault(p => p.Key == "Name").Value);
         Assert.Equal(42, metadata.FirstOrDefault(p => p.Key == "Age").Value);
     }
@@ -24,7 +24,7 @@ public class MetadataHelperTestFixture
     [Fact]
     public void Scan_single_attribute_into_an_enumerable_set()
     {
-        var metadata = MetadataHelper.GetMetadata(typeof(WeakTypedScenario));
+        var metadata = MetadataHelper.GetMetadata(typeof(WeakTypedScenario)).ToList();
 
         Assert.Single(metadata);
         Assert.Equal("Hello", metadata.FirstOrDefault(p => p.Key == "Name").Value);
@@ -33,9 +33,9 @@ public class MetadataHelperTestFixture
     [Fact]
     public void Scan_strongly_typed_attribute_into_an_enumerable_set()
     {
-        var metadata = MetadataHelper.GetMetadata<IStrongTypedScenarioMetadata>(typeof(StrongTypedScenario));
+        var metadata = MetadataHelper.GetMetadata<IStrongTypedScenarioMetadata>(typeof(StrongTypedScenario)).ToList();
 
-        Assert.Equal(2, metadata.Count());
+        Assert.Equal(2, metadata.Count);
         Assert.Equal("Hello", metadata.FirstOrDefault(p => p.Key == "Name").Value);
         Assert.Equal(42, metadata.FirstOrDefault(p => p.Key == "Age").Value);
     }
@@ -43,7 +43,7 @@ public class MetadataHelperTestFixture
     [Fact]
     public void Verify_that_unfound_strong_typed_attribute_results_in_empty_property_set()
     {
-        var metadata = MetadataHelper.GetMetadata<IMetadataModuleScenarioMetadata>(typeof(MetadataModuleScenario));
+        var metadata = MetadataHelper.GetMetadata<IMetadataModuleScenarioMetadata>(typeof(MetadataModuleScenario)).ToList();
 
         Assert.Empty(metadata);
     }
@@ -51,7 +51,7 @@ public class MetadataHelperTestFixture
     [Fact]
     public void Verify_that_unfound_weakly_typed_attribute_results_in_empty_property_set()
     {
-        var metadata = MetadataHelper.GetMetadata(typeof(MetadataModuleScenario));
+        var metadata = MetadataHelper.GetMetadata(typeof(MetadataModuleScenario)).ToList();
 
         Assert.Empty(metadata);
     }

--- a/test/Autofac.Extras.AttributeMetadata.Test/MetadataModuleTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/MetadataModuleTestFixture.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.MetadataModuleScenarioDiscoveryTargets;
 using Xunit;
 

--- a/test/Autofac.Extras.AttributeMetadata.Test/MetadataProviderTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/MetadataProviderTestFixture.cs
@@ -23,8 +23,8 @@ public class MetadataProviderTestFixture
         var withMetadata = container.Resolve<Meta<IMetadataProviderScenario>>();
 
         Assert.NotNull(withMetadata);
-        var value1 = withMetadata.Metadata.Where(kv => kv.Key == "Key1").FirstOrDefault();
-        var value2 = withMetadata.Metadata.Where(kv => kv.Key == "Key2").FirstOrDefault();
+        var value1 = withMetadata.Metadata.FirstOrDefault(kv => kv.Key == "Key1");
+        var value2 = withMetadata.Metadata.FirstOrDefault(kv => kv.Key == "Key2");
 
         Assert.Equal("Value1", value1.Value);
         Assert.Equal("Value2", value2.Value);

--- a/test/Autofac.Extras.AttributeMetadata.Test/MetadataProviderTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/MetadataProviderTestFixture.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Linq;
-using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.MetadataProviderScenarioTypes;
 using Autofac.Features.Metadata;
 using Xunit;

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakAgeMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakAgeMetadataAttribute.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.CombinationalWeakTypedAttributeScenario;

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakAgeMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakAgeMetadataAttribute.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.CombinationalWeakTypedAttributeScenario;
 
 [MetadataAttribute]
+[AttributeUsage(AttributeTargets.Class)]
 public sealed class CombinationalWeakAgeMetadataAttribute : Attribute
 {
     public CombinationalWeakAgeMetadataAttribute(int age)

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakNameMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakNameMetadataAttribute.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.CombinationalWeakTypedAttributeScenario;
 
 [MetadataAttribute]
+[AttributeUsage(AttributeTargets.Class)]
 public sealed class CombinationalWeakNameMetadataAttribute : Attribute
 {
     public CombinationalWeakNameMetadataAttribute(string name)

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakNameMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakNameMetadataAttribute.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.CombinationalWeakTypedAttributeScenario;

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakTypedScenario.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/CombinationalWeakTypedAttributeScenario/CombinationalWeakTypedScenario.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.CombinationalWeakTypedAttributeScenario;
 
 [CombinationalWeakNameMetadata("Hello")]

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/MetadataModuleScenarioDiscoveryTargets/StrongTypedScenarioMetadataModule.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/MetadataModuleScenarioDiscoveryTargets/StrongTypedScenarioMetadataModule.cs
@@ -11,6 +11,8 @@ public class StrongTypedScenarioMetadataModule : MetadataModule<IMetadataModuleS
 {
     public override void Register(IMetadataRegistrar<IMetadataModuleScenario, IMetadataModuleScenarioMetadata> registrar)
     {
+        ArgumentNullException.ThrowIfNull(registrar);
+
         registrar.RegisterType<MetadataModuleScenario>(new MetadataModuleScenarioMetadata("sid"));
         registrar.RegisterType<MetadataModuleScenario>(new MetadataModuleScenarioMetadata("nancy"));
 

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/MetadataModuleScenarioDiscoveryTargets/TypeOfScenarioMetadataModule.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/MetadataModuleScenarioDiscoveryTargets/TypeOfScenarioMetadataModule.cs
@@ -7,6 +7,8 @@ public class TypeOfScenarioMetadataModule : MetadataModule<IMetadataModuleScenar
 {
     public override void Register(IMetadataRegistrar<IMetadataModuleScenario, IMetadataModuleScenarioMetadata> registrar)
     {
+        ArgumentNullException.ThrowIfNull(registrar);
+
         registrar.RegisterType(typeof(MetadataModuleScenario), new MetadataModuleScenarioMetadata("sid"));
         registrar.RegisterType(typeof(MetadataModuleScenario), new MetadataModuleScenarioMetadata("nancy"));
 

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/MetadataProviderScenario/ProvidedMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/MetadataProviderScenario/ProvidedMetadataAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.MetadataProviderScenarioTypes;

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/NestedLifetimeScopeRegistrationScenario/NestedLifetimeScopeRegistrationMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/NestedLifetimeScopeRegistrationScenario/NestedLifetimeScopeRegistrationMetadataAttribute.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.NestedLifetimeScopeRegistrationScenario;

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/StrongTypedMetadataAttributeScenario/StrongTypedScenarioMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/StrongTypedMetadataAttributeScenario/StrongTypedScenarioMetadataAttribute.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
-using System.Linq;
 
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.StrongTypedMetadataAttributeScenario;
 

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/StrongTypedMetadataAttributeScenario/StrongTypedScenarioMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/StrongTypedMetadataAttributeScenario/StrongTypedScenarioMetadataAttribute.cs
@@ -8,6 +8,7 @@ using System.Linq;
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.StrongTypedMetadataAttributeScenario;
 
 [MetadataAttribute]
+[AttributeUsage(AttributeTargets.Class)]
 public sealed class StrongTypedScenarioMetadataAttribute : Attribute, IStrongTypedScenarioMetadata
 {
     public StrongTypedScenarioMetadataAttribute(string name, int age)

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/WeakTypedMetadataAttributeScenario/WeakTypedScenarioMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/WeakTypedMetadataAttributeScenario/WeakTypedScenarioMetadataAttribute.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.WeakTypedMetadataAttributeScenario;

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/WeakTypedMetadataAttributeScenario/WeakTypedScenarioMetadataAttribute.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/WeakTypedMetadataAttributeScenario/WeakTypedScenarioMetadataAttribute.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 namespace Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.WeakTypedMetadataAttributeScenario;
 
 [MetadataAttribute]
+[AttributeUsage(AttributeTargets.Class)]
 public sealed class WeakTypedScenarioMetadataAttribute : Attribute
 {
     public WeakTypedScenarioMetadataAttribute(string name)

--- a/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/WeakTypedMetadataAttributeScenario/WeakTypedScenarioMetadataModule.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/ScenarioTypes/WeakTypedMetadataAttributeScenario/WeakTypedScenarioMetadataModule.cs
@@ -18,6 +18,8 @@ public class WeakTypedScenarioMetadataModule : MetadataModule<IWeakTypedScenario
 
     public override void Register(IMetadataRegistrar<IWeakTypedScenario, IWeakTypedScenarioMetadata> registrar)
     {
+        ArgumentNullException.ThrowIfNull(registrar);
+
         if (_useGeneric)
         {
             registrar.RegisterAttributedType<WeakTypedScenario>();

--- a/test/Autofac.Extras.AttributeMetadata.Test/StrongTypedAttributeScenarioTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/StrongTypedAttributeScenarioTestFixture.cs
@@ -32,7 +32,7 @@ public class StrongTypedAttributeScenarioTestFixture
         Assert.Single(items, p => p.Metadata.Name == "Hello" && p.Metadata.Age == 42);
         Assert.Single(items, p => p.Metadata.Name == "Goodbye" && p.Metadata.Age == 24);
 
-        Assert.IsType<StrongTypedScenario>(items.Where(p => p.Metadata.Name == "Hello" && p.Metadata.Age == 42).First().Value);
-        Assert.IsType<AlternateStrongTypedScenario>(items.Where(p => p.Metadata.Name == "Goodbye" && p.Metadata.Age == 24).First().Value);
+        Assert.IsType<StrongTypedScenario>(items.First(p => p.Metadata.Name == "Hello" && p.Metadata.Age == 42).Value);
+        Assert.IsType<AlternateStrongTypedScenario>(items.First(p => p.Metadata.Name == "Goodbye" && p.Metadata.Age == 24).Value);
     }
 }

--- a/test/Autofac.Extras.AttributeMetadata.Test/StrongTypedAttributeScenarioTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/StrongTypedAttributeScenarioTestFixture.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.StrongTypedMetadataAttributeScenario;
 using Autofac.Integration.Mef;

--- a/test/Autofac.Extras.AttributeMetadata.Test/StrongTypedAttributeScenarioTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/StrongTypedAttributeScenarioTestFixture.cs
@@ -22,10 +22,10 @@ public class StrongTypedAttributeScenarioTestFixture
             .WithAttributedMetadata<IStrongTypedScenarioMetadata>();
 
         // act
-        var items = builder.Build().Resolve<IEnumerable<Lazy<IStrongTypedScenario, IStrongTypedScenarioMetadata>>>();
+        var items = builder.Build().Resolve<IEnumerable<Lazy<IStrongTypedScenario, IStrongTypedScenarioMetadata>>>().ToList();
 
         // assert
-        Assert.Equal(2, items.Count());
+        Assert.Equal(2, items.Count);
         Assert.Single(items, p => p.Metadata.Name == "Hello" && p.Metadata.Age == 42);
         Assert.Single(items, p => p.Metadata.Name == "Goodbye" && p.Metadata.Age == 24);
 

--- a/test/Autofac.Extras.AttributeMetadata.Test/WeakTypeAttributedMetadataModuleTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/WeakTypeAttributedMetadataModuleTestFixture.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.CombinationalWeakTypedAttributeScenario;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.WeakTypedMetadataAttributeScenario;
 using Xunit;

--- a/test/Autofac.Extras.AttributeMetadata.Test/WeakTypedAttributeScenarioTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/WeakTypedAttributeScenarioTestFixture.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using Autofac;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.WeakTypedMetadataAttributeScenario;
 using Autofac.Integration.Mef;
 using Xunit;

--- a/test/Autofac.Extras.AttributeMetadata.Test/WeakTypedScenarioMetadataModuleTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/WeakTypedScenarioMetadataModuleTestFixture.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Autofac.Extras.AttributeMetadata.Test.ScenarioTypes.WeakTypedMetadataAttributeScenario;
 using Xunit;
 

--- a/test/Autofac.Extras.AttributeMetadata.Test/WithAttributeFilterTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/WithAttributeFilterTestFixture.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
 using Autofac.Features.Metadata;
 using Autofac.Features.OwnedInstances;
@@ -384,13 +385,13 @@ public class WithAttributeFilterTestFixture
         [WithKey("Solution")] IEnumerable<IAdapter> adapters,
         [WithKey("Solution")] ILogger logger)
         {
-            Adapters = adapters.ToList();
+            Adapters = new Collection<IAdapter>(adapters.ToList());
             Logger = logger;
         }
 
-        public List<IAdapter> Adapters
+        public Collection<IAdapter> Adapters
         {
-            get; set;
+            get;
         }
 
         public ILogger Logger
@@ -405,13 +406,13 @@ public class WithAttributeFilterTestFixture
         [WithMetadata("Target", "Solution")] IEnumerable<IAdapter> adapters,
         [WithMetadata("LoggerName", "Solution")] ILogger logger)
         {
-            Adapters = adapters.ToList();
+            Adapters = new Collection<IAdapter>(adapters.ToList());
             Logger = logger;
         }
 
-        public List<IAdapter> Adapters
+        public Collection<IAdapter> Adapters
         {
-            get; set;
+            get;
         }
 
         public ILogger Logger
@@ -426,13 +427,13 @@ public class WithAttributeFilterTestFixture
         [WithMetadata("Target", "Solution")] IEnumerable<IAdapter> adapters,
         [WithKey("Solution")] ILogger logger)
         {
-            Adapters = adapters.ToList();
+            Adapters = new Collection<IAdapter>(adapters.ToList());
             Logger = logger;
         }
 
-        public List<IAdapter> Adapters
+        public Collection<IAdapter> Adapters
         {
-            get; set;
+            get;
         }
 
         public ILogger Logger
@@ -460,6 +461,11 @@ public class WithAttributeFilterTestFixture
         public string Target
         {
             get; internal set;
+        }
+
+        public IDictionary<string, object> Metadata
+        {
+            get;
         }
     }
 

--- a/test/Autofac.Extras.AttributeMetadata.Test/WithAttributeFilterTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/WithAttributeFilterTestFixture.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 using Autofac.Features.Metadata;
 using Autofac.Features.OwnedInstances;
 using Xunit;

--- a/test/Autofac.Extras.AttributeMetadata.Test/WithAttributeFilterTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/WithAttributeFilterTestFixture.cs
@@ -445,6 +445,7 @@ public class WithAttributeFilterTestFixture
     }
 
     [MetadataAttribute]
+    [AttributeUsage(AttributeTargets.Class)]
     public sealed class AdapterAttribute : Attribute
     {
         public AdapterAttribute(string target)
@@ -466,6 +467,7 @@ public class WithAttributeFilterTestFixture
     }
 
     [MetadataAttribute]
+    [AttributeUsage(AttributeTargets.Class)]
     public sealed class EmptyMetadataAttribute : Attribute
     {
     }

--- a/test/Autofac.Extras.AttributeMetadata.Test/WithAttributeFilterTestFixture.cs
+++ b/test/Autofac.Extras.AttributeMetadata.Test/WithAttributeFilterTestFixture.cs
@@ -454,6 +454,8 @@ public class WithAttributeFilterTestFixture
 
         public AdapterAttribute(IDictionary<string, object> metadata)
         {
+            ArgumentNullException.ThrowIfNull(metadata);
+
             Target = (string)metadata["Target"];
         }
 


### PR DESCRIPTION
## Summary

- Adds SonarAnalyzer.CSharp (10.27.0.140913) to all projects
- Introduces unified `build/Source.ruleset` and `build/Test.ruleset` with consistent analyzer configuration
- Fixes all actionable analyzer warnings (code changes per-rule in individual commits)
- Disables rules that are false positives or inapplicable for this project's patterns

## Changes

- **New analyzer**: SonarAnalyzer.CSharp added via PackageReference with PrivateAssets=all
- **Rulesets**: Unified Source.ruleset and Test.ruleset covering Microsoft, Sonar, StyleCop, and xUnit analyzers
- **Code fixes**: Various warning fixes committed individually by rule ID for easy review
- **Zero warnings**: Build completes with no analyzer warnings

## Test plan

- [ ] CI build passes (zero errors, zero warnings)
- [ ] All existing tests pass
- [ ] No public API changes (verify with `dotnet format --verify-no-changes`)